### PR TITLE
Load sql file option

### DIFF
--- a/docs/20-prerequisites.mdx
+++ b/docs/20-prerequisites.mdx
@@ -38,6 +38,11 @@ docker run -p 5432:5432 sample-postgres-library
 ```
 The PostgreSQL server can be accessed at localhost:5432 with a username of `postgres` and a password of `postgres`.
 
+### Option 4: Load an SQL file
+Choose this option if you just want a quick hands-on experience and you don't need to run actual migration.
+Download the file [library-schema.sql](https://github.com/mongodb-developer/relational-migrator-lab/blob/main/resource/library-schema.sql)
+and upload this file later on at the **create a project** step. However, you will not be able to perform an actual migration if you not have a source database. 
+
 ## 2. MongoDB Database
 
 As we'll be importing data from a Relational Database into MongoDB, you'll need to have a MongoDB database. You have a 

--- a/docs/50-Create a Project/50-create-new-project.mdx
+++ b/docs/50-Create a Project/50-create-new-project.mdx
@@ -12,7 +12,7 @@ Ensure Relational Migrator is installed and running (normally at http://127.0.0.
 <Screenshot url="https://www.mongodb.com/products/tools/relational-migrator" src="img/50-image-001.png" alt="Screenshot of the connect modal" />
 
 ## Select an option
-Click **Connect to live database**
-Click **Load schema from a file** if you NOT have access to a source database.
+1. Click **Connect to live database**
+2. Click **Load schema from a file** if you NOT have access to a source database.
 
 <Screenshot url="https://www.mongodb.com/products/tools/relational-migrator" src="img/50-image-002.png" alt="Screenshot of the connect modal" />

--- a/docs/50-Create a Project/50-create-new-project.mdx
+++ b/docs/50-Create a Project/50-create-new-project.mdx
@@ -11,6 +11,8 @@ Ensure Relational Migrator is installed and running (normally at http://127.0.0.
 
 <Screenshot url="https://www.mongodb.com/products/tools/relational-migrator" src="img/50-image-001.png" alt="Screenshot of the connect modal" />
 
-## Click Connect to live database
+## Select an option
+Click **Connect to live database**
+Click **Load schema from a file** if you NOT have access to a source database.
 
 <Screenshot url="https://www.mongodb.com/products/tools/relational-migrator" src="img/50-image-002.png" alt="Screenshot of the connect modal" />


### PR DESCRIPTION
Added an option to load an SQL file instead. This should be useful for live hands-on sessions so that participants need not setup their own relational database